### PR TITLE
Don't darken the hover state

### DIFF
--- a/_sass/agency.scss
+++ b/_sass/agency.scss
@@ -107,7 +107,7 @@ h1, h2, h3, h4, h5, h6 {
         &:focus,
         &:active,
         &.active {
-            color: darken($theme-primary, 10%);
+            color: $theme-primary;
         }
     }
     .navbar-collapse {
@@ -147,7 +147,7 @@ h1, h2, h3, h4, h5, h6 {
     .navbar-nav>.active>a:hover,
     .navbar-nav>.active>a:focus {
         color: white;
-        background-color: darken($theme-primary, 10%);
+        background-color: $theme-primary;
     }
 }
 


### PR DESCRIPTION
Since we're not using the primary colors anyway, just use the primary theme.

Top of page:

![image](https://user-images.githubusercontent.com/239241/36623284-20958dac-18b8-11e8-83fd-c0434b07170b.png)


Further down:

![image](https://user-images.githubusercontent.com/239241/36623280-1a196494-18b8-11e8-8666-c4495912a095.png)
