### PR TITLE
add envoy and cncf logos

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,32 +17,48 @@ limitations under the License.
 <!-- Footer -->
 
 <footer>
+    <div class="incubated-by">
+        <ul class="list-inline">
+            <li>
+                <a href="https://www.envoyproxy.io" target="_blank">
+                    <img class="footer-logo-small" src="https://raw.githubusercontent.com/cncf/artwork/master/envoy/horizontal/white/envoy-horizontal-white.png" alt="Envoy" />
+                </a>
+            </li>
+            <li>is incubated by
+            </li>
+            <li>
+                <a href="https://www.cncf.io/" target="_blank">
+                    <img class="footer-logo-small" src ="https://raw.githubusercontent.com/cncf/artwork/master/cncf/horizontal/white/cncf-white.png" alt="CNCF" />
+                </a>
+            </li>
+        </ul>
+    </div>
+     <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                <ul class="list-inline social-buttons">
+                    <li>
+                        <a href="http://twitter.com/learnenvoy" target="_blank">
+                            <i class="fab fa-twitter"></i>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://www.facebook.com/LearnEnvoyio-1597141557036599" target="_blank">
+                            <i class="fab fa-facebook"></i>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
     <div class="container">
         <div class="row">
-            <div class="col-md-4">
+            <div class="col-md-12">
                 <span class="copyright">Contributed by
-                    <a href="https://www.turbinelabs.io"><img class="footer-logo" src="/assets/img/logo-horiz-3c.svg" alt="Turbine Labs"/></a>
+                    <a href="https://www.turbinelabs.io">
+                        <img class="footer-logo-large" src="/assets/img/logo-horiz-3c.svg" alt="Turbine Labs"/>
+                    </a>
                 </span>
-            </div>
-            <div class="col-md-4">
-                <ul class="list-inline social-buttons">
-                    <li><a href="http://twitter.com/learnenvoy"><i class="fab fa-twitter"></i></a>
-                    </li>
-                    <li><a href="https://www.facebook.com/LearnEnvoyio-1597141557036599"><i class="fab fa-facebook"></i></a>
-                    </li>
-                    {% comment %}
-                    <li><a href="#"><i class="fa fa-linkedin"></i></a>
-                    </li>
-                    {% endcomment %}
-                </ul>
-            </div>
-            <div class="col-md-4">
-                <ul class="list-inline quicklinks">
-                    <li><a href="#">Privacy Policy</a>
-                    </li>
-                    <li><a href="#">Terms of Use</a>
-                    </li>
-                </ul>
             </div>
         </div>
     </div>

--- a/_sass/agency.scss
+++ b/_sass/agency.scss
@@ -175,7 +175,7 @@ h1, h2, h3, h4, h5, h6 {
 
 @media(min-width:768px) {
     .navbar-custom.affix {
-        background-color: $gray-darker;
+        background: linear-gradient(to right, $gray-darker, $gray-dark);
         padding: 10px 0;
         .navbar-brand {
             font-size: 1.5em;
@@ -620,9 +620,6 @@ footer {
         line-height: 40px;
         @include body-font;
     }
-    img.footer-logo {
-        height: 50px;
-    }
 }
 
 // Social Buttons
@@ -644,7 +641,6 @@ ul.social-buttons {
             -moz-transition: all 0.3s;
             transition: all 0.3s;
             &:hover,
-            &:focus,
             &:active {
                 background-color: $theme-primary;
             }

--- a/_sass/learnenvoy.scss
+++ b/_sass/learnenvoy.scss
@@ -18,7 +18,7 @@ limitations under the License.
 @import "mixins.scss";
 
 header.article {
-  background: linear-gradient(to right, $gray-darker, $gray);
+  background: linear-gradient(to right, $gray-darker, $gray-dark);
   .intro-text {
     padding-top: 100px;
     padding-bottom: 50px;
@@ -62,5 +62,38 @@ header {
       padding-top: 25px;
       margin-top: 25px;
     }
+  }
+}
+
+ul.social-buttons {
+    li {
+        a {
+            &:focus {
+                background-color: $gray-darker;
+            }
+        }
+    }
+}
+
+footer {
+  padding-top:0px;
+  .incubated-by {
+    line-height: 75px;
+    background: linear-gradient(to right, $gray-darker, $gray-dark);
+    background-color: black;
+    color: white;
+    padding-top: 15px;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+    margin-top:0px;
+  }
+  img.footer-logo-large {
+      height: 80px;
+  }
+  img.footer-logo-small {
+      height: 50px;
+  }
+  div {
+    margin-top:5px;
   }
 }


### PR DESCRIPTION
Add the white variants of the logos, in their own black (ok darker gray -> dark gray gradient) strip, because:

1) the white logos don't conflict brand-wise
2) it mirrors the header
3) it breaks up the content a little better
4) it works well against the both the white of article pages and the grey of the signup page

<img width="975" alt="screen shot 2018-02-26 at 2 52 57 pm" src="https://user-images.githubusercontent.com/362808/36700651-4cce4b4e-1b05-11e8-870b-b8ab19e08d90.png">
<img width="407" alt="screen shot 2018-02-26 at 2 52 40 pm" src="https://user-images.githubusercontent.com/362808/36700652-4ddd111e-1b05-11e8-8a26-61cfa39d92fa.png">

Also got rid of the terms of service and privacy policy links for now, since we don't have those. 

Also change the header banner and splash gradient in the article pages to be consistent with the envoy/cncf strip. 

Also make off-site links open in `_blank`, and fix a resulting bug where the social icons stayed orange forever after clicking on them.