### PR TITLE
add copy button for console, json, yaml code blocks

### DIFF
--- a/_articles/getting-help.md
+++ b/_articles/getting-help.md
@@ -25,7 +25,7 @@ configured separately in the case of a custom xDS configuration.
 
 `GET /logging`
 
-You can also pass these flags to the envoy binary:
+You can also pass these flags to the Envoy binary:
 
 ```console
 -l <string>, --log-level <string> --log-path <path string>

--- a/_articles/getting-help.md
+++ b/_articles/getting-help.md
@@ -25,7 +25,7 @@ configured separately in the case of a custom xDS configuration.
 
 `GET /logging`
 
-You can also pass this command in your CLI:
+You can also pass these flags to the envoy binary:
 
 ```console
 -l <string>, --log-level <string> --log-path <path string>

--- a/_articles/on-your-laptop.md
+++ b/_articles/on-your-laptop.md
@@ -80,6 +80,9 @@ Running `docker-compose ps` should show the following output:
 
 ```console
 $ docker-compose ps
+```
+
+```shell
           Name                        Command               State                      Ports
 ----------------------------------------------------------------------------------------------------------------
 frontproxy_front-envoy_1   /bin/sh -c /usr/local/bin/ ...   Up      0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
@@ -95,6 +98,9 @@ localhost:8000/service/1`. You should see
 
 ```console
 $ curl localhost:8000/service/1
+```
+
+```shell
 Hello from behind Envoy (service 1)! hostname: 6632a613837e resolvedhostname: 172.19.0.3
 ```
 
@@ -102,6 +108,9 @@ Going to http://localhost:8000/service/2 should result in
 
 ```console
 $ curl localhost:8000/service/2
+```
+
+```shell
 Hello from behind Envoy (service 2)! hostname: bf97b0b3294d resolvedhostname: 172.19.0.2
 ```
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -51,6 +51,10 @@ limitations under the License.
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 
+    <!-- to make consol code copyable -->
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script type="text/javascript" src="{{ "/assets/codeButton.js" | relative_url }}"></script>
+
     <!-- Various vendor scripts -->
     <script type="text/javascript" src="{{ "/assets/vendor.js" | relative_url }}"></script>
     <script src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>

--- a/_sass/learnenvoy.scss
+++ b/_sass/learnenvoy.scss
@@ -97,3 +97,26 @@ footer {
     margin-top:5px;
   }
 }
+
+button.tbn-btn-code-copy {
+  background: none;
+  border: none;
+  border: solid 1px rgba(0,0,0,0);
+  border-radius: 4px;
+  color: #999;
+  cursor: pointer;
+  display: block;
+  float: right;
+  margin-top: 0;
+  transition: all 0.2s;
+  width: 30px;
+}
+
+button.tbn-btn-code-copy:active {
+  background-color: $theme-secondary;
+  outline: none;
+}
+
+button.tbn-btn-code-copy:hover {
+  border-color: $theme-primary;
+}

--- a/assets/codeButton.js
+++ b/assets/codeButton.js
@@ -1,0 +1,42 @@
+function stripPrompts(s) {
+  // replace any leading '$' plus any whitespace (\s*) with the empty string
+  // options: (g = global, m = multiline)
+  return s.replace(/^\$\s*/gm, '')
+}
+
+const languageSelector = '.language-console, .language-json, .language-yaml'
+
+function handleClick(e) {
+  e.preventDefault()
+  e.stopPropagation()
+  // get the button's parent's child language-console code block
+  var code = $(e.delegateTarget).parent().find(languageSelector)
+  // process the text. TODO #3140: be more robust about when not to strip
+  // leading $. OK for now, since leading $ are illegal in both yaml and json.
+  var copyString = stripPrompts(code.text())
+  // get the global copy input field and set its value to the processed string
+  var input = $('.tbn-code-copy-input').val(copyString)
+  // select the input field
+  input.select()
+  // tell the browser to copy the currently selected text
+  try {
+    document.execCommand('copy')
+  } catch (e) {}
+  // un-focus the input element so Firefox doesn't try to scroll to it.
+  input.blur()
+}
+
+$(function() {
+  // create the hidden input
+  $('body').append('<textarea class="tbn-code-copy-input"></textarea>')
+  // actually hide it by moving it off screen
+  $('.tbn-code-copy-input').css('position', 'absolute').css('left', '-9999px')
+  // get all the 'console' code blocks and add a copy button immediately after them
+  // NOTE: Firefox choked on parsing prettier's formatting for the next block, so...
+  // prettier-ignore
+  $(languageSelector)
+    .parent()
+    .before('<button class="tbn-btn-code-copy"><img class="tbn-btn-icon-copy" width="16" height="16" alt="Copy" src="/assets/copy_icon.svg" /></button>')
+  // add handlers to all the new copy buttons
+  var buttons = $('.tbn-btn-code-copy').on('click', handleClick)
+})

--- a/assets/copy_icon.svg
+++ b/assets/copy_icon.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+</svg>


### PR DESCRIPTION
Add a copy button for all console, yaml, and json code blocks. 

The code is copied from the Turbine Labs docs site. 

Also rework the "on your laptop" markdown to separate commands from output.

![in the clipboard](https://user-images.githubusercontent.com/362808/37228273-e6ed64ac-2394-11e8-8c81-0f6aad5a788c.gif)

<img width="739" alt="console and shell" src="https://user-images.githubusercontent.com/362808/37228252-d773bd96-2394-11e8-91a9-2b1b46001808.png">

<img width="739" alt="json" src="https://user-images.githubusercontent.com/362808/37228253-d79097fe-2394-11e8-87c8-084bf1192189.png">



