### PR TITLE
Use correct field in `route.HeaderRoutes`

### DIFF
--- a/_articles/incremental-deploys.md
+++ b/_articles/incremental-deploys.md
@@ -97,7 +97,7 @@ routes:
     prefix: "/service/1"
     headers:
       - name: "x-canary-version"
-        value: "service1a"
+        exact_match: "service1a"
   route:
     cluster: service1a
 - match:


### PR DESCRIPTION
`value` is only included in api-v1 docs. In the api-v2 docs you need to specify one of : 
> Only one of exact_match, regex_match, range_match, present_match, prefix_match, suffix_match may be set.